### PR TITLE
1.10.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Workflow only runs `flutter test`; no push/PR creation, so the
+          # default GITHUB_TOKEN credentials don't need to persist on disk.
+          persist-credentials: false
 
       - name: Set up Flutter
         # subosito/flutter-action is the standard community action for installing Flutter on

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Tests
+
+on:
+  pull_request:
+
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  flutter-test:
+    name: flutter test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        # subosito/flutter-action is the standard community action for installing Flutter on
+        # GitHub-hosted runners. Pinning to a major tag lets minor updates roll in safely.
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Run tests
+        run: flutter test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Add `setUserAttributes` public method.
 - Add notification action button surface: `buttons`, `clickedButtonIndex`, `clickedButton`, `clickedUrl`.
-- Add `FlareLaneWebViewBridge` helper for hybrid apps (see README).
+- Add `FlareLaneJavascriptInterface` adapter for `webview_flutter` and `flutter_inappwebview` hybrid apps (see README).
 - Bump native dependencies to FlareLane Android/iOS SDK 1.10.0.
 
 ## 1.9.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.10.0
+
+- Add `setUserAttributes` public method.
+- Add notification action button surface: `buttons`, `clickedButtonIndex`, `clickedButton`, `clickedUrl`.
+- Add `FlareLaneWebViewBridge` helper for hybrid apps (see README).
+- Bump native dependencies to FlareLane Android/iOS SDK 1.10.0.
+
 ## 1.9.2
 
 - Upgrade Android SDK (1.8.4)

--- a/README.md
+++ b/README.md
@@ -26,12 +26,19 @@ add only the one you actually use to your own app's `pubspec.yaml`.
 
 ### webview_flutter
 
+The adapter factories take a `WebViewController` and read it eagerly, so
+construct the controller first, then wire the bridge into that same
+instance — don't reference the controller inside its own initialization
+cascade.
+
 ```dart
 import 'package:webview_flutter/webview_flutter.dart';
 import 'package:flarelane_flutter/adapters/webview_flutter.dart';
 
 final controller = WebViewController()
-  ..setJavaScriptMode(JavaScriptMode.unrestricted)
+  ..setJavaScriptMode(JavaScriptMode.unrestricted);
+
+controller
   // additive slot — adapter channel sits alongside your own channels.
   ..addJavaScriptChannel('MyChannel', onMessageReceived: myChannelHandler)
   ..addJavaScriptChannel(

--- a/README.md
+++ b/README.md
@@ -1,3 +1,124 @@
 # FlareLane-Flutter-SDK
 
 Welcome to [FlareLane](https://flarelane.com)
+
+## WebView Bridge (hybrid apps)
+
+For hybrid apps that embed pages running the FlareLane Web SDK, the plugin
+exposes a bridge so identity (`deviceId` / `userId` / `projectId`) and SDK
+calls (`setUserId`, `setTags`, `trackEvent`, `setUserAttributes`,
+`syncDeviceData`) stay aligned between native and web.
+
+The bridge name and class name match the native Android/iOS SDKs:
+`FlareLaneJavascriptInterface` + `BRIDGE_NAME`. The plugin ships
+library-named adapters that expose members 1:1 with each webview library's
+slot names — drop them into your existing webview wiring.
+
+Two webview libraries are supported as first-class adapters:
+
+| Webview library | Adapter import |
+|---|---|
+| `webview_flutter` (official) | `package:flarelane_flutter/adapters/webview_flutter.dart` |
+| `flutter_inappwebview` | `package:flarelane_flutter/adapters/flutter_inappwebview.dart` |
+
+The webview libraries are **not** transitive dependencies of this plugin —
+add only the one you actually use to your own app's `pubspec.yaml`.
+
+### webview_flutter
+
+```dart
+import 'package:webview_flutter/webview_flutter.dart';
+import 'package:flarelane_flutter/adapters/webview_flutter.dart';
+
+final controller = WebViewController()
+  ..setJavaScriptMode(JavaScriptMode.unrestricted)
+  // additive slot — adapter channel sits alongside your own channels.
+  ..addJavaScriptChannel('MyChannel', onMessageReceived: myChannelHandler)
+  ..addJavaScriptChannel(
+    FlareLaneJavascriptInterface.BRIDGE_NAME,
+    onMessageReceived:
+        FlareLaneJavascriptInterface.onMessageReceived(controller),
+  )
+  // single-valued slot — call adapter callback inside your own callback.
+  ..setNavigationDelegate(NavigationDelegate(
+    onPageStarted: (url) async {
+      await FlareLaneJavascriptInterface.onPageStarted(controller)(url);
+      myExistingOnPageStarted(url);
+    },
+    onPageFinished: myExistingOnPageFinished,
+  ));
+```
+
+The adapter exposes:
+
+- `FlareLaneJavascriptInterface.BRIDGE_NAME` — channel name constant.
+- `FlareLaneJavascriptInterface.onMessageReceived(controller)` — factory
+  that returns a callback for `addJavaScriptChannel(…, onMessageReceived: …)`.
+- `FlareLaneJavascriptInterface.onPageStarted(controller)` — factory that
+  returns a callback for `NavigationDelegate(onPageStarted: …)`.
+
+### flutter_inappwebview
+
+```dart
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:flarelane_flutter/adapters/flutter_inappwebview.dart';
+
+InAppWebView(
+  initialUrlRequest: URLRequest(url: WebUri(url)),
+  // additive slot — merge adapter UserScripts with your own.
+  initialUserScripts: UnmodifiableListView<UserScript>([
+    ...FlareLaneJavascriptInterface.initialUserScripts,
+    ...myUserScripts,
+  ]),
+  // single-valued slot — register the adapter handler inside your own callback.
+  onWebViewCreated: (controller) {
+    controller.addJavaScriptHandler(
+      handlerName: FlareLaneJavascriptInterface.BRIDGE_NAME,
+      callback: FlareLaneJavascriptInterface.handlerCallback(controller),
+    );
+    myExistingOnWebViewCreated(controller);
+  },
+);
+```
+
+The adapter exposes:
+
+- `FlareLaneJavascriptInterface.BRIDGE_NAME` — channel name constant.
+- `FlareLaneJavascriptInterface.initialUserScripts` — a `UserScript` list
+  for `InAppWebView(initialUserScripts: …)`. Injection time is
+  `AT_DOCUMENT_START` so the Web SDK detects the bridge before its own
+  scripts run.
+- `FlareLaneJavascriptInterface.handlerCallback(controller)` — factory
+  that returns a callback for `controller.addJavaScriptHandler(…, callback: …)`.
+
+### Class name collision (rare)
+
+Both adapter files declare `class FlareLaneJavascriptInterface`. In typical
+apps you import only one of them, so there is no collision. If you must
+import both in the same Dart file, use `import as` prefixes:
+
+```dart
+import 'package:flarelane_flutter/adapters/webview_flutter.dart' as fl_wvf;
+import 'package:flarelane_flutter/adapters/flutter_inappwebview.dart' as fl_iaw;
+
+fl_wvf.FlareLaneJavascriptInterface.BRIDGE_NAME
+fl_iaw.FlareLaneJavascriptInterface.BRIDGE_NAME
+```
+
+### Other webview packages
+
+This plugin only ships first-class adapters for `webview_flutter` and
+`flutter_inappwebview`. If you use a different webview library, port one
+of the adapter implementations in `lib/adapters/` to your library's slot
+names — the shared message routing and injection script logic lives in
+`lib/src/bridge_core.dart` (internal) and is the source of truth.
+
+### Notes
+
+- The injected JS is idempotent — safe to inject twice.
+- Inject *before* the Web SDK loads. With `webview_flutter`, the adapter
+  uses `onPageStarted` which is usually fast enough; for stricter timing,
+  `flutter_inappwebview`'s `AT_DOCUMENT_START` UserScript injection (built
+  into that adapter) is preferred.
+- `setUserAttributes` is available on Android, iOS, Flutter, and React
+  Native SDKs with consistent semantics.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,5 +37,5 @@ android {
 }
 
 dependencies {
-    implementation 'com.github.flarelane:FlareLane-Android-SDK:1.8.4'
+    implementation 'com.github.flarelane:FlareLane-Android-SDK:1.10.0'
 }

--- a/android/src/main/java/com/flarelane/flarelane_flutter/FlareLaneFlutterPlugin.java
+++ b/android/src/main/java/com/flarelane/flarelane_flutter/FlareLaneFlutterPlugin.java
@@ -48,7 +48,7 @@ public class FlareLaneFlutterPlugin implements FlutterPlugin, MethodCallHandler 
     channel.setMethodCallHandler(this);
 
     FlareLane.SdkInfo.type = SdkType.FLUTTER;
-    FlareLane.SdkInfo.version = "1.9.2";
+    FlareLane.SdkInfo.version = "1.10.0";
   }
 
   @Override
@@ -142,6 +142,29 @@ public class FlareLaneFlutterPlugin implements FlutterPlugin, MethodCallHandler 
         final JSONObject data = _data instanceof HashMap ? new JSONObject((HashMap<String, Object>) _data) : null;
         FlareLane.displayInApp(mContext, group, data);
         result.success(true);
+      } else if (call.method.equals("setUserAttributes")) {
+        final HashMap<String, Object> attributes = call.arguments();
+        final JSONObject json = attributes != null ? new JSONObject(attributes) : new JSONObject();
+        FlareLane.setUserAttributes(mContext, json);
+        result.success(true);
+      } else if (call.method.equals("_webViewSyncPayload")) {
+        // Helper-only entry: returns identifiers for the WebView bridge to
+        // build a syncDeviceDataCallback payload. Not part of the public API.
+        // On internal failure return an all-null normalized map (matches the
+        // RN bridge) so the Web SDK still sees a syncDeviceDataCallback
+        // invocation instead of nothing.
+        HashMap<String, Object> payload = new HashMap<>();
+        try {
+          payload.put("projectId", FlareLane.getProjectId(mContext));
+          payload.put("deviceId", FlareLane.getDeviceId(mContext));
+          payload.put("userId", FlareLane.getUserId(mContext));
+        } catch (Exception e) {
+          Log.e("FlareLane", Log.getStackTraceString(e));
+          payload.put("projectId", null);
+          payload.put("deviceId", null);
+          payload.put("userId", null);
+        }
+        result.success(payload);
       } else {
         result.notImplemented();
       }

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g
 android.useAndroidX=true
 android.enableJetifier=true
 android.defaults.buildfeatures.buildconfig=true

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -19,6 +19,9 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0" // apply true
     id "com.android.application" version "8.3.2" apply false
+    // webview_flutter_android 4.12+ uses Kotlin 1.9.20+ `compilerOptions` DSL.
+    // KGP 1.9.25 officially supports AGP 8.3.x (1.9.22 only goes up to AGP 8.1).
+    id "org.jetbrains.kotlin.android" version "1.9.25" apply false
 }
 
 include ":app"

--- a/example/assets/webview_websdk_test.html
+++ b/example/assets/webview_websdk_test.html
@@ -1,0 +1,190 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>FlareLane WebView Bridge Test</title>
+  <script src="https://cdn.flarelane.com/WebSDK.js" charset="UTF-8"></script>
+  <style>
+    body {
+      font-family: -apple-system, sans-serif;
+      margin: 0; padding: 12px 14px;
+      color: #111;
+    }
+    h2 { margin: 0 0 8px; text-align: center; font-size: 17px; }
+    .library-tag {
+      display: inline-block;
+      margin: 0 auto 8px;
+      padding: 3px 10px;
+      font-size: 11px;
+      color: #fff;
+      background: #0a84ff;
+      border-radius: 999px;
+    }
+    .library-line { text-align: center; }
+    .status {
+      background: #f7f7f7;
+      border-radius: 8px;
+      padding: 8px 10px;
+      margin: 8px 0 12px;
+      font-size: 12px;
+      line-height: 1.55;
+    }
+    .row { display: flex; align-items: flex-start; }
+    .row .mark { width: 18px; flex: none; }
+    .row .label { flex: 1; }
+    .row .detail {
+      margin-top: 2px;
+      color: #555;
+      font-size: 11px;
+      word-break: break-all;
+      white-space: pre-wrap;
+    }
+    .ok   .mark { color: #1aaf5d; }
+    .warn .mark { color: #c0922f; }
+    .fail .mark { color: #d6483a; }
+    .wait .mark { color: #999; }
+    button {
+      width: 100%; padding: 10px; margin: 4px 0;
+      background: #2c2c2c; color: #fff; border: none; border-radius: 8px;
+      font-size: 14px;
+    }
+    pre {
+      background: #f5f5f5; padding: 8px 10px; border-radius: 6px;
+      white-space: pre-wrap; word-break: break-all;
+      font-size: 11px; line-height: 1.4;
+      max-height: 180px; overflow: auto; margin: 8px 0 0;
+    }
+  </style>
+</head>
+<body>
+  <h2>WebView Bridge</h2>
+  <div class="library-line">
+    <span class="library-tag" id="libraryTag">webview: loading…</span>
+  </div>
+
+  <div class="status" id="status">
+    <div class="row wait" id="s-bridge">
+      <span class="mark">…</span>
+      <span class="label">Native bridge ready</span>
+    </div>
+    <div class="row wait" id="s-init">
+      <span class="mark">…</span>
+      <span class="label">FlareLane.initialize()</span>
+    </div>
+    <div class="row wait" id="s-sync">
+      <span class="mark">…</span>
+      <div style="flex:1;">
+        <div class="label">syncDeviceData (native → web)</div>
+        <div class="detail" id="s-sync-detail"></div>
+      </div>
+    </div>
+  </div>
+
+  <button id="setUserId">FlareLane.setUserId</button>
+  <button id="setTags">FlareLane.setTags</button>
+  <button id="trackEvent">FlareLane.trackEvent</button>
+  <button id="setUserAttributes">FlareLane.setUserAttributes</button>
+  <button id="displayInApp">FlareLane.displayInApp('home')</button>
+  <pre id="log">(log)</pre>
+
+  <script>
+    // Defaults applied when the page is opened standalone (no host overrides).
+    var DEFAULT_PROJECT_ID = 'a43cdc82-0ea5-4fdd-aebc-1940fe99b6c3';
+    var DEFAULT_LIBRARY = 'native';
+
+    function $(id) { return document.getElementById(id); }
+    function setRow(id, state, mark) {
+      var el = $(id);
+      el.classList.remove('wait','ok','warn','fail');
+      el.classList.add(state);
+      el.querySelector('.mark').innerText = mark;
+    }
+    function logLine(s) {
+      var prev = $('log').innerText;
+      $('log').innerText = s + '\n' + (prev === '(log)' ? '' : prev);
+    }
+    // Wait for whichever bridge surface the host exposes:
+    //   * RN/Flutter inject a JS shim that flips `__flareLaneBridgeInstalled`.
+    //   * iOS native sample uses WKScriptMessageHandler -> webkit.messageHandlers.
+    //   * Android native sample uses JavascriptInterface -> window.FlareLaneBridge.
+    function whenBridgeReady(cb) {
+      if (window.__flareLaneBridgeInstalled) return cb('shim');
+      if (typeof window.webkit !== 'undefined' &&
+          window.webkit.messageHandlers &&
+          window.webkit.messageHandlers.FlareLaneBridge) {
+        return cb('webkit');
+      }
+      if (typeof window.FlareLaneBridge === 'object' &&
+          typeof window.FlareLaneBridge.syncDeviceData === 'function') {
+        return cb('android');
+      }
+      setTimeout(function () { whenBridgeReady(cb); }, 50);
+    }
+    setTimeout(function () {
+      if ($('s-bridge').classList.contains('wait')) {
+        setRow('s-bridge', 'fail', '✗');
+        logLine('bridge not detected within 3s — host channel wiring missing?');
+      }
+    }, 3000);
+
+    whenBridgeReady(function (via) {
+      setRow('s-bridge', 'ok', '✓');
+      var projectId = window.__FLARELANE_PROJECT_ID__ || DEFAULT_PROJECT_ID;
+      var library = window.__FLARELANE_LIBRARY__ || DEFAULT_LIBRARY;
+      $('libraryTag').innerText = 'webview: ' + library + ' (bridge: ' + via + ')';
+
+      // Intercept syncDeviceDataCallback BEFORE initialize so the native
+      // response is never observed by an earlier `_orig` reference.
+      var _orig = FlareLane.syncDeviceDataCallback;
+      FlareLane.syncDeviceDataCallback = function (data) {
+        setRow('s-sync', 'ok', '✓');
+        $('s-sync-detail').innerText =
+          'projectId: ' + (data && data.projectId) +
+          '\ndeviceId: '  + (data && data.deviceId) +
+          '\nuserId: '    + (data && data.userId) +
+          '\nplatform: '  + (data && data.platform);
+        if (typeof _orig === 'function') _orig.call(FlareLane, data);
+      };
+      setTimeout(function () {
+        if ($('s-sync').classList.contains('wait')) {
+          setRow('s-sync', 'warn', '!');
+          $('s-sync-detail').innerText = 'no callback within 5s (check native bridge)';
+        }
+      }, 5000);
+
+      try {
+        FlareLane.initialize({ projectId: projectId });
+        setRow('s-init', 'ok', '✓');
+      } catch (e) {
+        setRow('s-init', 'fail', '✗');
+        logLine('initialize() threw: ' + e);
+      }
+    });
+
+    $('setUserId').onclick = function () {
+      FlareLane.setUserId('test_user');
+      logLine('> FlareLane.setUserId(test_user)');
+    };
+    $('setTags').onclick = function () {
+      FlareLane.setTags({ a: 'a', b: 'b' });
+      logLine('> FlareLane.setTags({a,b})');
+    };
+    $('trackEvent').onclick = function () {
+      FlareLane.trackEvent('webview_test', { x: 1 });
+      logLine('> FlareLane.trackEvent(webview_test)');
+    };
+    $('setUserAttributes').onclick = function () {
+      FlareLane.setUserAttributes({
+        name: 'Test User', email: 'test@example.com', phoneNumber: '+821012345678',
+        dob: '1990-01-01', timeZone: 'Asia/Seoul', country: 'KR', language: 'ko'
+      });
+      logLine('> FlareLane.setUserAttributes');
+    };
+    $('displayInApp').onclick = function () {
+      FlareLane.displayInApp('home');
+      logLine('> FlareLane.displayInApp(home)');
+    };
+  </script>
+</body>
+</html>

--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>12.0</string>
+  <string>13.0</string>
 </dict>
 </plist>

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-platform :ios, '12.0'
+platform :ios, '13.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
@@ -35,7 +35,7 @@ end
 
 target 'FlareLaneNotificationServiceExtension' do
   use_frameworks!
-  pod 'FlareLane', '1.9.2'
+  pod 'FlareLane', '1.10.0'
 end
 
 post_install do |installer|

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,28 +1,35 @@
 PODS:
-  - FlareLane (1.9.2)
+  - FlareLane (1.10.0)
   - flarelane_flutter (1.9.2):
-    - FlareLane (= 1.9.2)
+    - FlareLane (>= 1.10.0)
     - Flutter
   - Flutter (1.0.0)
+  - webview_flutter_wkwebview (0.0.1):
+    - Flutter
+    - FlutterMacOS
 
 DEPENDENCIES:
-  - FlareLane (from `/Users/minhyeok4dev/Documents/flarelane/FlareLane-iOS-SDK/FlareLane.podspec`)
+  - FlareLane (from `/Users/mh4dev/Documents/flarelane/FlareLane-SDKs/FlareLane-iOS-SDK`)
   - flarelane_flutter (from `.symlinks/plugins/flarelane_flutter/ios`)
   - Flutter (from `Flutter`)
+  - webview_flutter_wkwebview (from `.symlinks/plugins/webview_flutter_wkwebview/darwin`)
 
 EXTERNAL SOURCES:
   FlareLane:
-    :path: "/Users/minhyeok4dev/Documents/flarelane/FlareLane-iOS-SDK/FlareLane.podspec"
+    :path: "/Users/mh4dev/Documents/flarelane/FlareLane-SDKs/FlareLane-iOS-SDK"
   flarelane_flutter:
     :path: ".symlinks/plugins/flarelane_flutter/ios"
   Flutter:
     :path: Flutter
+  webview_flutter_wkwebview:
+    :path: ".symlinks/plugins/webview_flutter_wkwebview/darwin"
 
 SPEC CHECKSUMS:
-  FlareLane: 7adafe54757dabd7a63c3bfa0ff61c1cbd4c818d
-  flarelane_flutter: 865ff42317337589f13f702c3835a6964fe7d859
-  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  FlareLane: 39c1d22c435a60222d5ffa403bdffbf255540892
+  flarelane_flutter: 5587aaf70893d7f33c587013b7c969879e87bd73
+  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+  webview_flutter_wkwebview: 8ebf4fded22593026f7dbff1fbff31ea98573c8d
 
-PODFILE CHECKSUM: f52186af7f5680ddd9ab886474ce26b4019c394c
+PODFILE CHECKSUM: 53e7af77a67676bb7c4c8c1ac32962e843288bf7
 
 COCOAPODS: 1.16.2

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -17,7 +17,6 @@
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
-		C01DA0553EC044B0997F02DF /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 20728BB98D68EB084DFF5482 /* GoogleService-Info.plist */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -51,11 +50,9 @@
 		08A3F75CA56061ADF1720596 /* Pods-FlareLaneNotificationServiceExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FlareLaneNotificationServiceExtension.debug.xcconfig"; path = "Target Support Files/Pods-FlareLaneNotificationServiceExtension/Pods-FlareLaneNotificationServiceExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
-		20728BB98D68EB084DFF5482 /* GoogleService-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "Runner/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		25577587D95BFE2F53FE88EE /* Pods_FlareLaneNotificationServiceExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FlareLaneNotificationServiceExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		42EF4EE8274CA96A00045ACD /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
-		642EB84EABD1D8462226967C /* GoogleService-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "Runner/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
@@ -145,8 +142,6 @@
 				97C146EF1CF9000F007C117D /* Products */,
 				852FC21FB3DE57FAD0C09A1B /* Pods */,
 				5A1CDD5241401AF745641159 /* Frameworks */,
-				642EB84EABD1D8462226967C /* GoogleService-Info.plist */,
-				20728BB98D68EB084DFF5482 /* GoogleService-Info.plist */,
 			);
 			sourceTree = "<group>";
 		};
@@ -273,7 +268,6 @@
 				3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */,
 				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
 				97C146FC1CF9000F007C117D /* Main.storyboard in Resources */,
-				C01DA0553EC044B0997F02DF /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -440,7 +434,7 @@
 				INFOPLIST_FILE = FlareLaneNotificationServiceExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FlareLaneNotificationServiceExtension;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -478,7 +472,7 @@
 				INFOPLIST_FILE = FlareLaneNotificationServiceExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FlareLaneNotificationServiceExtension;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -513,7 +507,7 @@
 				INFOPLIST_FILE = FlareLaneNotificationServiceExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = FlareLaneNotificationServiceExtension;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -572,7 +566,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -593,7 +587,7 @@
 				DEVELOPMENT_TEAM = 2DX9GGF6S6;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -655,7 +649,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -705,7 +699,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -728,7 +722,7 @@
 				DEVELOPMENT_TEAM = 2DX9GGF6S6;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -755,7 +749,7 @@
 				DEVELOPMENT_TEAM = 2DX9GGF6S6;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -41,7 +41,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"

--- a/example/ios/Runner.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/example/ios/Runner.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>IDEDidComputeMac32BitWarning</key>
-	<true/>
-</dict>
-</plist>

--- a/example/ios/Runner.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/example/ios/Runner.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>PreviewsEnabled</key>
-	<false/>
-</dict>
-</plist>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -3,7 +3,10 @@ import 'dart:async';
 import 'package:flarelane_flutter/flarelane_flutter.dart';
 import 'package:flutter/material.dart';
 
-const FLARELANE_PROJECT_ID = 'FLARELANE_PROJECT_ID';
+import 'webview_bridge_demo.dart';
+import 'webview_bridge_inappwebview_demo.dart';
+
+const FLARELANE_PROJECT_ID = 'a43cdc82-0ea5-4fdd-aebc-1940fe99b6c3';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -32,6 +35,8 @@ class _MyAppState extends State<MyApp> {
   bool _isSetUserId = false;
   bool _isSubscribed = false;
   bool _isSetTags = false;
+  bool _isSetUserAttributes = false;
+  bool _isSubscribedState = false;
 
   @override
   void initState() {
@@ -39,8 +44,14 @@ class _MyAppState extends State<MyApp> {
 
     FlareLane.shared.setNotificationClickedHandler((notification) {
       setState(() {
-        _clickedMessage =
-            '✅ Message of clickedHandler\n${notification.toString()}';
+        final btn = notification.clickedButton;
+        final btnLine = btn != null
+            ? '\nclickedButton: ${btn.label} (index=${notification.clickedButtonIndex}) link=${btn.link ?? "-"}'
+            : '\nclickedButton: (body click)';
+        _clickedMessage = '✅ Message of clickedHandler\n'
+            '${notification.toString()}'
+            '$btnLine'
+            '\nclickedUrl: ${notification.clickedUrl ?? "-"}';
       });
     });
 
@@ -69,6 +80,14 @@ class _MyAppState extends State<MyApp> {
 
     FlareLane.shared.displayInApp("home");
 
+    // Sync initial subscribe-toggle label with the actual SDK state so the
+    // first tap doesn't appear inverted (e.g. already-subscribed device showing
+    // "set"). isSubscribed is one-shot; the toggle handlers keep it in sync
+    // after that.
+    FlareLane.shared.isSubscribed().then((subscribed) {
+      if (mounted) setState(() => _isSubscribedState = subscribed);
+    });
+
     setState(() {
       _resState = 'FlareLane initialized.';
     });
@@ -77,16 +96,16 @@ class _MyAppState extends State<MyApp> {
   Future<void> toggleUserId() async {
     await FlareLane.shared
         .setUserId(_isSetUserId ? null : "myuser@flarelane.com");
-    _isSetUserId = !_isSetUserId;
+    setState(() => _isSetUserId = !_isSetUserId);
   }
 
   Future<void> toggleTags() async {
     if (!_isSetTags) {
       await FlareLane.shared.setTags({"age": 27, "gender": 'men'});
-      _isSetTags = true;
+      setState(() => _isSetTags = true);
     } else {
       await FlareLane.shared.setTags({"age": null, "gender": null});
-      _isSetTags = false;
+      setState(() => _isSetTags = false);
     }
   }
 
@@ -98,16 +117,18 @@ class _MyAppState extends State<MyApp> {
     await FlareLane.shared.trackEvent("test_event", {"test": "event"});
   }
 
-  Future<void> subscribe() async {
-    await FlareLane.shared.subscribe(true, (isSubscribed) {
-      print(isSubscribed);
-    });
-  }
-
-  Future<void> unsubscribe() async {
-    await FlareLane.shared.unsubscribe((isSubscribed) {
-      print(isSubscribed);
-    });
+  Future<void> toggleSubscribe() async {
+    if (!_isSubscribedState) {
+      await FlareLane.shared.subscribe(true, (subscribed) {
+        print('subscribe -> $subscribed');
+        setState(() => _isSubscribedState = subscribed);
+      });
+    } else {
+      await FlareLane.shared.unsubscribe((subscribed) {
+        print('unsubscribe -> $subscribed');
+        setState(() => _isSubscribedState = subscribed);
+      });
+    }
   }
 
   Future<void> isSubscribed() async {
@@ -117,6 +138,32 @@ class _MyAppState extends State<MyApp> {
 
   Future<void> displayInApp() async {
     FlareLane.shared.displayInApp("home", {"test": "data", "test2": 123});
+  }
+
+  Future<void> toggleUserAttributes() async {
+    if (_isSetUserAttributes) {
+      await FlareLane.shared.setUserAttributes({
+        "name": null,
+        "email": null,
+        "phoneNumber": null,
+        "dob": null,
+        "timeZone": null,
+        "country": null,
+        "language": null,
+      });
+      setState(() => _isSetUserAttributes = false);
+    } else {
+      await FlareLane.shared.setUserAttributes({
+        "name": "Test User",
+        "email": "test@example.com",
+        "phoneNumber": "+821012345678",
+        "dob": "1990-01-01",
+        "timeZone": "Asia/Seoul",
+        "country": "KR",
+        "language": "ko",
+      });
+      setState(() => _isSetUserAttributes = true);
+    }
   }
 
   @override
@@ -131,21 +178,51 @@ class _MyAppState extends State<MyApp> {
           children: [
             Center(child: Text('$_resState\n\n$_clickedMessage')),
             OutlinedButton(
-                onPressed: toggleUserId, child: const Text("TOGGLE USER ID")),
+                onPressed: toggleUserId,
+                child: Text("TOGGLE USER ID (${_isSetUserId ? "del" : "set"})")),
             OutlinedButton(
-                onPressed: toggleTags, child: const Text("TOGGLE TAGS")),
+                onPressed: toggleTags,
+                child: Text("TOGGLE TAGS (${_isSetTags ? "del" : "set"})")),
+            OutlinedButton(
+                onPressed: toggleUserAttributes,
+                child: Text(
+                    "TOGGLE USER ATTRIBUTES (${_isSetUserAttributes ? "del" : "set"})")),
+            OutlinedButton(
+                onPressed: toggleSubscribe,
+                child: Text("TOGGLE SUBSCRIBE (${_isSubscribedState ? "del" : "set"})")),
             OutlinedButton(
                 onPressed: getDeviceId, child: const Text("PRINT DEVICE ID")),
             OutlinedButton(
                 onPressed: trackEvent, child: const Text("TRACK EVENT")),
             OutlinedButton(
-                onPressed: subscribe, child: const Text("SUBSCRIBE")),
-            OutlinedButton(
-                onPressed: unsubscribe, child: const Text("UNSUBSCRIBE")),
-            OutlinedButton(
                 onPressed: isSubscribed, child: const Text("ISSUBSCRIBED")),
             OutlinedButton(
-                onPressed: displayInApp, child: const Text("DISPLAY INAPP"))
+                onPressed: displayInApp, child: const Text("DISPLAY INAPP")),
+            const Padding(
+              padding: EdgeInsets.only(top: 12, bottom: 4),
+              child: Text(
+                'WebView Bridge',
+                style: TextStyle(fontSize: 12, color: Colors.grey),
+              ),
+            ),
+            OutlinedButton(
+                onPressed: () => Navigator.of(context).push(
+                      MaterialPageRoute<void>(
+                        builder: (_) => const WebViewBridgeDemo(
+                          projectId: FLARELANE_PROJECT_ID,
+                        ),
+                      ),
+                    ),
+                child: const Text("webview_flutter")),
+            OutlinedButton(
+                onPressed: () => Navigator.of(context).push(
+                      MaterialPageRoute<void>(
+                        builder: (_) => const WebViewBridgeInAppWebViewDemo(
+                          projectId: FLARELANE_PROJECT_ID,
+                        ),
+                      ),
+                    ),
+                child: const Text("flutter_inappwebview"))
           ],
         ),
       ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -44,9 +44,13 @@ class _MyAppState extends State<MyApp> {
 
     FlareLane.shared.setNotificationClickedHandler((notification) {
       setState(() {
+        // `clickedButtonIndex` is the source of truth for "was a button
+        // tapped?" — `clickedButton` can be null even on a button click when
+        // native sent an out-of-range index (see FlareLaneNotification docs).
+        final btnIndex = notification.clickedButtonIndex;
         final btn = notification.clickedButton;
-        final btnLine = btn != null
-            ? '\nclickedButton: ${btn.label} (index=${notification.clickedButtonIndex}) link=${btn.link ?? "-"}'
+        final btnLine = btnIndex != null
+            ? '\nclickedButton: ${btn?.label ?? "(out-of-range)"} (index=$btnIndex) link=${btn?.link ?? "-"}'
             : '\nclickedButton: (body click)';
         _clickedMessage = '✅ Message of clickedHandler\n'
             '${notification.toString()}'
@@ -173,57 +177,60 @@ class _MyAppState extends State<MyApp> {
         appBar: AppBar(
           title: const Text('FlareLane Example App'),
         ),
-        body: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Center(child: Text('$_resState\n\n$_clickedMessage')),
-            OutlinedButton(
-                onPressed: toggleUserId,
-                child: Text("TOGGLE USER ID (${_isSetUserId ? "del" : "set"})")),
-            OutlinedButton(
-                onPressed: toggleTags,
-                child: Text("TOGGLE TAGS (${_isSetTags ? "del" : "set"})")),
-            OutlinedButton(
-                onPressed: toggleUserAttributes,
+        body: SingleChildScrollView(
+          padding: const EdgeInsets.symmetric(vertical: 12),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Center(child: Text('$_resState\n\n$_clickedMessage')),
+              OutlinedButton(
+                  onPressed: toggleUserId,
+                  child: Text("TOGGLE USER ID (${_isSetUserId ? "del" : "set"})")),
+              OutlinedButton(
+                  onPressed: toggleTags,
+                  child: Text("TOGGLE TAGS (${_isSetTags ? "del" : "set"})")),
+              OutlinedButton(
+                  onPressed: toggleUserAttributes,
+                  child: Text(
+                      "TOGGLE USER ATTRIBUTES (${_isSetUserAttributes ? "del" : "set"})")),
+              OutlinedButton(
+                  onPressed: toggleSubscribe,
+                  child: Text("TOGGLE SUBSCRIBE (${_isSubscribedState ? "del" : "set"})")),
+              OutlinedButton(
+                  onPressed: getDeviceId, child: const Text("PRINT DEVICE ID")),
+              OutlinedButton(
+                  onPressed: trackEvent, child: const Text("TRACK EVENT")),
+              OutlinedButton(
+                  onPressed: isSubscribed, child: const Text("ISSUBSCRIBED")),
+              OutlinedButton(
+                  onPressed: displayInApp, child: const Text("DISPLAY INAPP")),
+              const Padding(
+                padding: EdgeInsets.only(top: 12, bottom: 4),
                 child: Text(
-                    "TOGGLE USER ATTRIBUTES (${_isSetUserAttributes ? "del" : "set"})")),
-            OutlinedButton(
-                onPressed: toggleSubscribe,
-                child: Text("TOGGLE SUBSCRIBE (${_isSubscribedState ? "del" : "set"})")),
-            OutlinedButton(
-                onPressed: getDeviceId, child: const Text("PRINT DEVICE ID")),
-            OutlinedButton(
-                onPressed: trackEvent, child: const Text("TRACK EVENT")),
-            OutlinedButton(
-                onPressed: isSubscribed, child: const Text("ISSUBSCRIBED")),
-            OutlinedButton(
-                onPressed: displayInApp, child: const Text("DISPLAY INAPP")),
-            const Padding(
-              padding: EdgeInsets.only(top: 12, bottom: 4),
-              child: Text(
-                'WebView Bridge',
-                style: TextStyle(fontSize: 12, color: Colors.grey),
+                  'WebView Bridge',
+                  style: TextStyle(fontSize: 12, color: Colors.grey),
+                ),
               ),
-            ),
-            OutlinedButton(
-                onPressed: () => Navigator.of(context).push(
-                      MaterialPageRoute<void>(
-                        builder: (_) => const WebViewBridgeDemo(
-                          projectId: FLARELANE_PROJECT_ID,
+              OutlinedButton(
+                  onPressed: () => Navigator.of(context).push(
+                        MaterialPageRoute<void>(
+                          builder: (_) => const WebViewBridgeDemo(
+                            projectId: FLARELANE_PROJECT_ID,
+                          ),
                         ),
                       ),
-                    ),
-                child: const Text("webview_flutter")),
-            OutlinedButton(
-                onPressed: () => Navigator.of(context).push(
-                      MaterialPageRoute<void>(
-                        builder: (_) => const WebViewBridgeInAppWebViewDemo(
-                          projectId: FLARELANE_PROJECT_ID,
+                  child: const Text("webview_flutter")),
+              OutlinedButton(
+                  onPressed: () => Navigator.of(context).push(
+                        MaterialPageRoute<void>(
+                          builder: (_) => const WebViewBridgeInAppWebViewDemo(
+                            projectId: FLARELANE_PROJECT_ID,
+                          ),
                         ),
                       ),
-                    ),
-                child: const Text("flutter_inappwebview"))
-          ],
+                  child: const Text("flutter_inappwebview"))
+            ],
+          ),
         ),
       ),
     );

--- a/example/lib/webview_bridge_demo.dart
+++ b/example/lib/webview_bridge_demo.dart
@@ -24,25 +24,30 @@ class _WebViewBridgeDemoState extends State<WebViewBridgeDemo> {
   @override
   void initState() {
     super.initState();
-    _controller = WebViewController()
-      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+    // The adapter factories read the controller eagerly, so build the
+    // controller into a local variable first, wire the bridge into that
+    // same instance, then publish it to the `_controller` field.
+    final controller = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted);
+    controller
       // additive slot — bridge channel sits alongside any customer-owned
       // channels added with different names.
       ..addJavaScriptChannel(
         FlareLaneJavascriptInterface.BRIDGE_NAME,
         onMessageReceived:
-            FlareLaneJavascriptInterface.onMessageReceived(_controller),
+            FlareLaneJavascriptInterface.onMessageReceived(controller),
       )
       // single-valued slot — compose adapter and customer callbacks. The
       // demo has no extra customer logic, but this is where it would go:
       //   onPageStarted: (url) async {
-      //     await FlareLaneJavascriptInterface.onPageStarted(_controller)(url);
+      //     await FlareLaneJavascriptInterface.onPageStarted(controller)(url);
       //     myExistingOnPageStarted(url);
       //   },
       ..setNavigationDelegate(NavigationDelegate(
         onPageStarted:
-            FlareLaneJavascriptInterface.onPageStarted(_controller),
+            FlareLaneJavascriptInterface.onPageStarted(controller),
       ));
+    _controller = controller;
     _loadAsset();
   }
 

--- a/example/lib/webview_bridge_demo.dart
+++ b/example/lib/webview_bridge_demo.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:webview_flutter/webview_flutter.dart';
+// Library-named adapter — same `FlareLaneJavascriptInterface` class name as
+// native Android/iOS, with members shaped to webview_flutter's slot names.
+import 'package:flarelane_flutter/adapters/webview_flutter.dart';
+
+/// Demo wiring the `FlareLaneJavascriptInterface` adapter into
+/// `webview_flutter` using the coexist pattern (the customer's own slot
+/// callbacks compose with the adapter's bridge callbacks).
+class WebViewBridgeDemo extends StatefulWidget {
+  const WebViewBridgeDemo({Key? key, required this.projectId})
+      : super(key: key);
+
+  final String projectId;
+
+  @override
+  State<WebViewBridgeDemo> createState() => _WebViewBridgeDemoState();
+}
+
+class _WebViewBridgeDemoState extends State<WebViewBridgeDemo> {
+  late final WebViewController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      // additive slot — bridge channel sits alongside any customer-owned
+      // channels added with different names.
+      ..addJavaScriptChannel(
+        FlareLaneJavascriptInterface.BRIDGE_NAME,
+        onMessageReceived:
+            FlareLaneJavascriptInterface.onMessageReceived(_controller),
+      )
+      // single-valued slot — compose adapter and customer callbacks. The
+      // demo has no extra customer logic, but this is where it would go:
+      //   onPageStarted: (url) async {
+      //     await FlareLaneJavascriptInterface.onPageStarted(_controller)(url);
+      //     myExistingOnPageStarted(url);
+      //   },
+      ..setNavigationDelegate(NavigationDelegate(
+        onPageStarted:
+            FlareLaneJavascriptInterface.onPageStarted(_controller),
+      ));
+    _loadAsset();
+  }
+
+  Future<void> _loadAsset() async {
+    String html =
+        await rootBundle.loadString('assets/webview_websdk_test.html');
+    html = html
+        .replaceAll('%PROJECT_ID%', widget.projectId)
+        .replaceAll('%LIBRARY%', 'webview_flutter');
+    await _controller.loadHtmlString(html, baseUrl: 'https://localhost');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Stack(
+          children: [
+            WebViewWidget(controller: _controller),
+            Positioned(
+              top: 8,
+              right: 12,
+              child: _CloseButton(onTap: () => Navigator.of(context).pop()),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _CloseButton extends StatelessWidget {
+  const _CloseButton({Key? key, required this.onTap}) : super(key: key);
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.black54,
+      shape: const CircleBorder(),
+      child: InkWell(
+        customBorder: const CircleBorder(),
+        onTap: onTap,
+        child: const SizedBox(
+          width: 36,
+          height: 36,
+          child: Center(
+            child: Icon(Icons.close, color: Colors.white, size: 22),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/webview_bridge_inappwebview_demo.dart
+++ b/example/lib/webview_bridge_inappwebview_demo.dart
@@ -32,6 +32,10 @@ class _WebViewBridgeInAppWebViewDemoState
   Future<void> _loadAsset() async {
     String html =
         await rootBundle.loadString('assets/webview_websdk_test.html');
+    // The async asset load can resolve after this State is disposed (e.g. the
+    // user pops the route before the bundle finishes reading). Guard the
+    // setState so we don't touch an unmounted element.
+    if (!mounted) return;
     html = html
         .replaceAll('%PROJECT_ID%', widget.projectId)
         .replaceAll('%LIBRARY%', 'flutter_inappwebview');

--- a/example/lib/webview_bridge_inappwebview_demo.dart
+++ b/example/lib/webview_bridge_inappwebview_demo.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+// Library-named adapter — same `FlareLaneJavascriptInterface` class name as
+// native Android/iOS, with members shaped to flutter_inappwebview's slot
+// names.
+import 'package:flarelane_flutter/adapters/flutter_inappwebview.dart';
+
+/// Demo wiring the `FlareLaneJavascriptInterface` adapter into
+/// `flutter_inappwebview` using the coexist pattern.
+class WebViewBridgeInAppWebViewDemo extends StatefulWidget {
+  const WebViewBridgeInAppWebViewDemo({Key? key, required this.projectId})
+      : super(key: key);
+
+  final String projectId;
+
+  @override
+  State<WebViewBridgeInAppWebViewDemo> createState() =>
+      _WebViewBridgeInAppWebViewDemoState();
+}
+
+class _WebViewBridgeInAppWebViewDemoState
+    extends State<WebViewBridgeInAppWebViewDemo> {
+  String? _html;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadAsset();
+  }
+
+  Future<void> _loadAsset() async {
+    String html =
+        await rootBundle.loadString('assets/webview_websdk_test.html');
+    html = html
+        .replaceAll('%PROJECT_ID%', widget.projectId)
+        .replaceAll('%LIBRARY%', 'flutter_inappwebview');
+    setState(() => _html = html);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_html == null) {
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+    }
+    return Scaffold(
+      body: SafeArea(
+        child: Stack(
+          children: [
+            InAppWebView(
+              initialData: InAppWebViewInitialData(
+                data: _html!,
+                baseUrl: Uri.parse('https://localhost'),
+              ),
+              // additive slot — adapter UserScripts sit alongside any
+              // customer-owned scripts. Spread to merge:
+              //   initialUserScripts: UnmodifiableListView<UserScript>([
+              //     ...FlareLaneJavascriptInterface.initialUserScripts,
+              //     ...myUserScripts,
+              //   ]),
+              initialUserScripts:
+                  FlareLaneJavascriptInterface.initialUserScripts,
+              initialOptions: InAppWebViewGroupOptions(
+                crossPlatform: InAppWebViewOptions(javaScriptEnabled: true),
+              ),
+              // single-valued slot — customer composes inside onWebViewCreated.
+              onWebViewCreated: (controller) {
+                controller.addJavaScriptHandler(
+                  handlerName: FlareLaneJavascriptInterface.BRIDGE_NAME,
+                  callback: FlareLaneJavascriptInterface.handlerCallback(
+                      controller),
+                );
+                // customer's other handler registrations / init logic goes here.
+              },
+            ),
+            Positioned(
+              top: 8,
+              right: 12,
+              child: _CloseButton(onTap: () => Navigator.of(context).pop()),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _CloseButton extends StatelessWidget {
+  const _CloseButton({Key? key, required this.onTap}) : super(key: key);
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: Colors.black54,
+      shape: const CircleBorder(),
+      child: InkWell(
+        customBorder: const CircleBorder(),
+        onTap: onTap,
+        child: const SizedBox(
+          width: 36,
+          height: 36,
+          child: Center(
+            child: Icon(Icons.close, color: Colors.white, size: 22),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -63,12 +63,20 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.9.2"
+    version: "1.10.0"
   flutter:
     dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_inappwebview:
+    dependency: "direct main"
+    description:
+      name: flutter_inappwebview
+      sha256: d198297060d116b94048301ee6749cd2e7d03c1f2689783f52d210a6b7aba350
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.8.0"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -86,26 +94,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -146,6 +154,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -195,18 +211,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.6"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -215,6 +231,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "15.0.0"
+  webview_flutter:
+    dependency: "direct main"
+    description:
+      name: webview_flutter
+      sha256: a3da219916aba44947d3a5478b1927876a09781174b5a2b67fa5be0555154bf9
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.13.1"
+  webview_flutter_android:
+    dependency: transitive
+    description:
+      name: webview_flutter_android
+      sha256: ad5182eff9a550925330cb9f0cb038eddfdd5712aba8b77aa0f0400e50f6e688
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.12.0"
+  webview_flutter_platform_interface:
+    dependency: transitive
+    description:
+      name: webview_flutter_platform_interface
+      sha256: "1221c1b12f5278791042f2ec2841743784cf25c5a644e23d6680e5d718824f04"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.15.1"
+  webview_flutter_wkwebview:
+    dependency: transitive
+    description:
+      name: webview_flutter_wkwebview
+      sha256: e50cd97ad28e888f6a4f862a05eab917a635417f9b134df64c3abb78250c6446
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.25.0"
 sdks:
-  dart: ">=3.7.0-0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  dart: ">=3.9.0 <4.0.0"
+  flutter: ">=3.35.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -31,6 +31,11 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
 
+  # WebView Bridge demo dependencies — two libraries are wired so the same
+  # FlareLane Web SDK end-to-end flow can be verified across packages.
+  webview_flutter: ^4.7.0
+  flutter_inappwebview: ^5.8.0
+
   # Other Libraries
 
 dev_dependencies:
@@ -58,6 +63,9 @@ flutter:
   # assets:
   #   - images/a_dot_burr.jpeg
   #   - images/a_dot_ham.jpeg
+
+  assets:
+    - assets/webview_websdk_test.html
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/assets-and-images/#resolution-aware.

--- a/ios/Classes/SwiftFlareLaneFlutterPlugin.swift
+++ b/ios/Classes/SwiftFlareLaneFlutterPlugin.swift
@@ -101,10 +101,13 @@ public class SwiftFlareLaneFlutterPlugin: NSObject, FlutterPlugin {
     } else if (method == "_webViewSyncPayload") {
       // Helper-only entry: returns identifiers for the WebView bridge to
       // build a syncDeviceDataCallback payload. Not part of the public API.
-      let payload: [String: Any?] = [
-        "projectId": FlareLane.getProjectId(),
-        "deviceId": FlareLane.getDeviceId(),
-        "userId": FlareLane.getUserId()
+      // Map unset identifiers to NSNull explicitly — Flutter's standard
+      // codec encodes NSNull as Dart `null`, while a Swift `Optional.none`
+      // inside `[String: Any?]` is not a documented codec input.
+      let payload: [String: Any] = [
+        "projectId": FlareLane.getProjectId() ?? NSNull(),
+        "deviceId": FlareLane.getDeviceId() ?? NSNull(),
+        "userId": FlareLane.getUserId() ?? NSNull()
       ]
       result(payload)
     }

--- a/ios/Classes/SwiftFlareLaneFlutterPlugin.swift
+++ b/ios/Classes/SwiftFlareLaneFlutterPlugin.swift
@@ -19,7 +19,7 @@ public class SwiftFlareLaneFlutterPlugin: NSObject, FlutterPlugin {
     // Register appDelegate
     registrar.addApplicationDelegate(instance)
 
-    FlareLane.setSdkInfo(sdkType: .flutter, sdkVersion: "1.9.2")
+    FlareLane.setSdkInfo(sdkType: .flutter, sdkVersion: "1.10.0")
   }
 
   // ----- FLUTTER INVOKE HANDLER -----
@@ -94,6 +94,19 @@ public class SwiftFlareLaneFlutterPlugin: NSObject, FlutterPlugin {
       result(true)
     } else if (method == "getDeviceId") {
       result(self.getDeviceId())
+    } else if (method == "setUserAttributes") {
+      let attributes = call.arguments as? [String: Any] ?? [:]
+      self.setUserAttributes(attributes: attributes)
+      result(true)
+    } else if (method == "_webViewSyncPayload") {
+      // Helper-only entry: returns identifiers for the WebView bridge to
+      // build a syncDeviceDataCallback payload. Not part of the public API.
+      let payload: [String: Any?] = [
+        "projectId": FlareLane.getProjectId(),
+        "deviceId": FlareLane.getDeviceId(),
+        "userId": FlareLane.getUserId()
+      ]
+      result(payload)
     }
     else {
       result(false)
@@ -137,6 +150,10 @@ public class SwiftFlareLaneFlutterPlugin: NSObject, FlutterPlugin {
 
   func setTags(tags: [String: Any]) {
     FlareLane.setTags(tags: tags)
+  }
+
+  func setUserAttributes(attributes: [String: Any]) {
+    FlareLane.setUserAttributes(attributes: attributes)
   }
 
   func trackEvent(type: String, data: [String: Any]?) {

--- a/ios/flarelane_flutter.podspec
+++ b/ios/flarelane_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flarelane_flutter'
-  s.version          = '1.9.2'
+  s.version          = '1.10.0'
   s.summary          = 'FlareLane Flutter SDK'
   s.description      = <<-DESC
 FlareLane Flutter SDK
@@ -17,7 +17,7 @@ FlareLane Flutter SDK
   s.dependency 'Flutter'
   s.platform = :ios, '12.0'
 
-  s.dependency "FlareLane", '1.9.2'
+  s.dependency "FlareLane", '1.10.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/lib/adapters/flutter_inappwebview.dart
+++ b/lib/adapters/flutter_inappwebview.dart
@@ -1,0 +1,75 @@
+import 'dart:collection';
+
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+
+import '../src/bridge_core.dart';
+
+// flutter_inappwebview routes JS-to-native through `callHandler`. The bridge
+// shim built into `BridgeCore.javaScriptInjection` targets a
+// generic channel named `window.FlareLaneNativeBridge`, so a tiny adapter
+// translates that funnel into flutter_inappwebview's actual API call.
+const String _channelAdapter = '''
+  window.FlareLaneNativeBridge = {
+    postMessage: function (s) {
+      window.flutter_inappwebview.callHandler('FlareLaneNativeBridge', s);
+    }
+  };
+''';
+
+/// `flutter_inappwebview`-specific adapter exposing the FlareLane bridge in
+/// shape that matches `flutter_inappwebview`'s `InAppWebView` widget slots
+/// (`initialUserScripts`, `addJavaScriptHandler` via `onWebViewCreated`).
+///
+/// Example — alongside the customer's existing user scripts / handlers:
+///
+/// ```dart
+/// InAppWebView(
+///   initialUrlRequest: URLRequest(url: WebUri(url)),
+///   initialUserScripts: UnmodifiableListView([
+///     ...FlareLaneJavascriptInterface.initialUserScripts,
+///     ...myUserScripts,
+///   ]),
+///   onWebViewCreated: (controller) {
+///     controller.addJavaScriptHandler(
+///       handlerName: FlareLaneJavascriptInterface.BRIDGE_NAME,
+///       callback: FlareLaneJavascriptInterface.handlerCallback(controller),
+///     );
+///     myOnWebViewCreated(controller);
+///   },
+/// );
+/// ```
+class FlareLaneJavascriptInterface {
+  /// Channel name constant — mirrors the native SDK's `BRIDGE_NAME`.
+  // ignore: constant_identifier_names
+  static const String BRIDGE_NAME = 'FlareLaneNativeBridge';
+
+  /// `UserScript` list ready to plug into
+  /// `InAppWebView(initialUserScripts: …)`. Installs the bridge shim at
+  /// document start so the Web SDK detects `window.FlareLaneBridge` before
+  /// any page scripts run.
+  static UnmodifiableListView<UserScript> get initialUserScripts =>
+      UnmodifiableListView<UserScript>([
+        UserScript(
+          source: _channelAdapter + BridgeCore.javaScriptInjection,
+          injectionTime: UserScriptInjectionTime.AT_DOCUMENT_START,
+        ),
+      ]);
+
+  /// Returns a callback ready to plug into
+  /// `controller.addJavaScriptHandler(handlerName: BRIDGE_NAME, callback: …)`.
+  /// Each incoming message is routed through the FlareLane bridge core; if
+  /// the core returns a JS string (e.g. the `syncDeviceData` response), it
+  /// is evaluated back into the webview via the controller.
+  static Future<void> Function(List<dynamic>) handlerCallback(
+      InAppWebViewController controller) {
+    return (List<dynamic> args) async {
+      final String message =
+          args.isNotEmpty && args.first is String ? args.first as String : '';
+      if (message.isEmpty) return;
+      final String? js = await BridgeCore.handle(message);
+      if (js != null) {
+        await controller.evaluateJavascript(source: js);
+      }
+    };
+  }
+}

--- a/lib/adapters/webview_flutter.dart
+++ b/lib/adapters/webview_flutter.dart
@@ -50,9 +50,13 @@ class FlareLaneJavascriptInterface {
   }
 
   /// Returns a callback ready to plug into
-  /// `NavigationDelegate(onPageStarted: …)`. Injects the bridge shim at the
-  /// start of every page load so the Web SDK can detect
-  /// `window.FlareLaneBridge` before its own scripts run.
+  /// `NavigationDelegate(onPageStarted: …)`. Injects the bridge shim near
+  /// the start of page load. `webview_flutter` does not expose a true
+  /// document-start hook, so an inline `<head>` script that reads
+  /// `window.FlareLaneBridge` synchronously may still run before the shim
+  /// on some platforms. For strict document-start timing, prefer the
+  /// `flutter_inappwebview` adapter (which uses `AT_DOCUMENT_START`
+  /// UserScript injection).
   static Future<void> Function(String) onPageStarted(
       WebViewController controller) {
     return (String url) async {

--- a/lib/adapters/webview_flutter.dart
+++ b/lib/adapters/webview_flutter.dart
@@ -1,0 +1,63 @@
+import 'package:webview_flutter/webview_flutter.dart';
+
+import '../src/bridge_core.dart';
+
+/// `webview_flutter`-specific adapter that exposes the FlareLane bridge in
+/// shape that matches `webview_flutter`'s controller slot names. The bridge
+/// protocol (`BridgeCore.javaScriptInjection` + `handle`) is
+/// reused as-is from the low-level core.
+///
+/// Customers wire their `WebViewController` as usual — the adapter members
+/// (`onMessageReceived(controller)`, `onPageStarted(controller)`) drop into
+/// the matching slot 1:1 by name.
+///
+/// Example — alongside the customer's existing channels / navigation callbacks:
+///
+/// ```dart
+/// final controller = WebViewController()
+///   ..setJavaScriptMode(JavaScriptMode.unrestricted)
+///   ..addJavaScriptChannel('MyChannel', onMessageReceived: myHandler)
+///   ..addJavaScriptChannel(
+///     FlareLaneJavascriptInterface.BRIDGE_NAME,
+///     onMessageReceived:
+///         FlareLaneJavascriptInterface.onMessageReceived(controller),
+///   )
+///   ..setNavigationDelegate(NavigationDelegate(
+///     onPageStarted: (url) async {
+///       await FlareLaneJavascriptInterface.onPageStarted(controller)(url);
+///       myOnPageStarted(url);
+///     },
+///   ));
+/// ```
+class FlareLaneJavascriptInterface {
+  /// Channel name constant — mirrors the native SDK's `BRIDGE_NAME`.
+  // ignore: constant_identifier_names
+  static const String BRIDGE_NAME = 'FlareLaneNativeBridge';
+
+  /// Returns a callback ready to plug into
+  /// `controller.addJavaScriptChannel(BRIDGE_NAME, onMessageReceived: …)`.
+  /// Each incoming message is routed through the FlareLane bridge core; if
+  /// the core returns a JS string (e.g. the `syncDeviceData` response), it
+  /// is evaluated back into the webview via the controller.
+  static Future<void> Function(JavaScriptMessage) onMessageReceived(
+      WebViewController controller) {
+    return (JavaScriptMessage message) async {
+      final String? js = await BridgeCore.handle(message.message);
+      if (js != null) {
+        await controller.runJavaScript(js);
+      }
+    };
+  }
+
+  /// Returns a callback ready to plug into
+  /// `NavigationDelegate(onPageStarted: …)`. Injects the bridge shim at the
+  /// start of every page load so the Web SDK can detect
+  /// `window.FlareLaneBridge` before its own scripts run.
+  static Future<void> Function(String) onPageStarted(
+      WebViewController controller) {
+    return (String url) async {
+      await controller
+          .runJavaScript(BridgeCore.javaScriptInjection);
+    };
+  }
+}

--- a/lib/flarelane_flutter.dart
+++ b/lib/flarelane_flutter.dart
@@ -59,6 +59,13 @@ class FlareLane {
     await _channel.invokeMethod('setTags', tags);
   }
 
+  /// Set user attributes (name/email/phoneNumber/dob/timeZone/country/language, etc.).
+  /// Sent only when userId is set, matching Web SDK behavior.
+  Future<void> setUserAttributes(Map<String, Object?> attributes) async {
+    debugPrint('[FlareLane] setUserAttributes: $attributes');
+    await _channel.invokeMethod('setUserAttributes', attributes);
+  }
+
   Future<bool> isSubscribed() async {
     final bool _isSubscribed = await _channel.invokeMethod('isSubscribed');
     return _isSubscribed;

--- a/lib/notification.dart
+++ b/lib/notification.dart
@@ -21,6 +21,10 @@ class FlareLaneNotificationButton {
       link: link is String ? link : null,
     );
   }
+
+  @override
+  String toString() =>
+      'FlareLaneNotificationButton{label: $label, link: $link}';
 }
 
 /// Pure data class — every field is populated from the native bridge payload (no derived

--- a/lib/notification.dart
+++ b/lib/notification.dart
@@ -1,5 +1,32 @@
-import 'dart:convert';
+class FlareLaneNotificationButton {
+  final String label;
+  final String? link;
 
+  FlareLaneNotificationButton({required this.label, this.link});
+
+  /// Parse a button entry from the bridge payload, returning `null` when the entry is
+  /// malformed (missing/non-string/empty `label`). A `factory` constructor can't return
+  /// null, so this is a regular static method — callers filter the nulls out instead of
+  /// catching a runtime cast error. Native already drops empty-label entries before
+  /// sending; this is a defensive net for unexpected wire shapes.
+  static FlareLaneNotificationButton? fromJson(Map json) {
+    final label = json['label'];
+    if (label is! String || label.isEmpty) return null;
+    // Defensively check `link` shape too: a non-String value would crash the
+    // `as String?` cast at runtime. Drop unexpected shapes silently — better
+    // to lose the link than to take the host app down.
+    final link = json['link'];
+    return FlareLaneNotificationButton(
+      label: label,
+      link: link is String ? link : null,
+    );
+  }
+}
+
+/// Pure data class — every field is populated from the native bridge payload (no derived
+/// logic, no branching). Native (Android/iOS) is the single source of truth for "what was
+/// clicked / where to go"; this layer just reflects what it was handed. Keep it that way
+/// to avoid drift between platforms.
 class FlareLaneNotification {
   late String id;
   String? title;
@@ -7,6 +34,20 @@ class FlareLaneNotification {
   String? url;
   String? imageUrl;
   Map? data;
+  List<FlareLaneNotificationButton>? buttons;
+
+  /// Index of the action button that was tapped, or `null` for a body click. Doubles as the
+  /// "was it a button click?" check via `notification.clickedButtonIndex != null`.
+  int? clickedButtonIndex;
+
+  /// The button that was tapped, or `null` for a body click / out-of-range index.
+  FlareLaneNotificationButton? clickedButton;
+
+  /// URL associated with the click:
+  ///   - Button click → the tapped button's link, or `null` when it has no link.
+  ///   - Body click   → the notification body's [url], or `null` when none is set.
+  /// A button click with no link returns `null`, **not** the body's [url].
+  String? clickedUrl;
 
   FlareLaneNotification(Map<String, dynamic> json) {
     if (json.containsKey('id')) id = json['id'] as String;
@@ -14,17 +55,33 @@ class FlareLaneNotification {
     if (json.containsKey('body')) body = json['body'] as String;
     if (json.containsKey('url')) url = json['url'] as String?;
     if (json.containsKey('imageUrl')) imageUrl = json['imageUrl'] as String?;
-    if (json.containsKey('data')) {
-      if (json['data'] is Map) {
-        data = json['data'];
-      } else if (json['data'] is String) {
-        data = jsonDecode(json['data']);
-      }
+    // Bridge always sends `data` as a parsed Map (iOS Dictionary / Android pre-parsed via
+    // toHashMap). No JSON-string fallback needed in this layer.
+    if (json['data'] is Map) {
+      data = json['data'];
+    }
+    if (json['buttons'] is List) {
+      // `fromJson` returns null on malformed entries; filter those out so the typed list
+      // never contains nulls.
+      buttons = (json['buttons'] as List)
+          .whereType<Map>()
+          .map((m) => FlareLaneNotificationButton.fromJson(m))
+          .whereType<FlareLaneNotificationButton>()
+          .toList();
+    }
+    if (json['clickedButtonIndex'] is int) {
+      clickedButtonIndex = json['clickedButtonIndex'] as int;
+    }
+    if (json['clickedButton'] is Map) {
+      clickedButton = FlareLaneNotificationButton.fromJson(json['clickedButton'] as Map);
+    }
+    if (json['clickedUrl'] is String) {
+      clickedUrl = json['clickedUrl'] as String?;
     }
   }
 
   @override
   String toString() {
-    return 'FlareLaneNotification{id: $id, title: $title, body: $body, url: $url, imageUrl: $imageUrl, data: $data}';
+    return 'FlareLaneNotification{id: $id, title: $title, body: $body, url: $url, imageUrl: $imageUrl, data: $data, buttons: $buttons, clickedButtonIndex: $clickedButtonIndex, clickedButton: $clickedButton, clickedUrl: $clickedUrl}';
   }
 }

--- a/lib/src/bridge_core.dart
+++ b/lib/src/bridge_core.dart
@@ -1,0 +1,145 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+import '../flarelane_flutter.dart';
+
+/// Internal bridge core shared by the webview library adapters under
+/// `lib/adapters/`. Not part of the package's public API — consumers should
+/// import the adapter that matches their webview library instead.
+///
+/// Exposes:
+///   * [javaScriptInjection] — JS snippet that installs `window.FlareLaneBridge`.
+///   * [handle] — routes one JSON message from the webview into the native
+///     FlareLane SDK and returns an optional response JS string the caller
+///     evaluates back into the webview (used by `syncDeviceData`).
+///
+/// Adapters layer on top of this with library-specific message-channel
+/// wrapping (e.g. `flutter_inappwebview.callHandler` vs `webview_flutter`'s
+/// `addJavaScriptChannel`).
+class BridgeCore {
+  BridgeCore._();
+
+  static const MethodChannel _channel =
+      MethodChannel('com.flarelane.flutter/methods');
+
+  /// JS snippet that installs `window.FlareLaneBridge`. Idempotent — safe to
+  /// inject multiple times (guarded by a flag on `window`).
+  static const String javaScriptInjection = _injectionScript;
+
+  /// Route a JSON message from the webview channel into the native SDK.
+  /// Returns a JS string to evaluate back into the webview (only for the
+  /// `syncDeviceData` response), or `null` otherwise. Never throws.
+  static Future<String?> handle(String message) async {
+    try {
+      final dynamic raw = jsonDecode(message);
+      if (raw is! Map) {
+        debugPrint('[FlareLane] WebView bridge ignored non-object message');
+        return null;
+      }
+      final Map<String, dynamic> body = raw.cast<String, dynamic>();
+      final String? method = body['method'] as String?;
+      if (method == null) {
+        debugPrint('[FlareLane] WebView bridge message missing "method"');
+        return null;
+      }
+
+      switch (method) {
+        case 'syncDeviceData':
+          return await _buildSyncDeviceDataCallback();
+        case 'setUserId':
+          await FlareLane.shared.setUserId(body['userId'] as String?);
+          return null;
+        case 'setTags':
+          final Map? tags = body['tags'] as Map?;
+          if (tags != null) {
+            await FlareLane.shared.setTags(tags.cast<String, Object?>());
+          }
+          return null;
+        case 'trackEvent':
+          final String? type = body['type'] as String?;
+          if (type == null) {
+            debugPrint('[FlareLane] trackEvent missing "type"');
+            return null;
+          }
+          final Map? data = body['data'] as Map?;
+          await FlareLane.shared
+              .trackEvent(type, data?.cast<String, Object>());
+          return null;
+        case 'setUserAttributes':
+          final Map? attributes = body['attributes'] as Map?;
+          if (attributes != null) {
+            await FlareLane.shared
+                .setUserAttributes(attributes.cast<String, Object?>());
+          }
+          return null;
+        default:
+          debugPrint('[FlareLane] WebView bridge unknown method: $method');
+          return null;
+      }
+    } catch (e) {
+      debugPrint('[FlareLane] WebView bridge handle failed: $e');
+      return null;
+    }
+  }
+
+  static Future<String?> _buildSyncDeviceDataCallback() async {
+    try {
+      final Map<dynamic, dynamic>? raw =
+          await _channel.invokeMethod<Map>('_webViewSyncPayload');
+      final Map<String, dynamic> payload =
+          raw?.cast<String, dynamic>() ?? <String, dynamic>{};
+      // Plugin returns projectId/deviceId/userId; platform is filled here so
+      // the native plugin handler stays generic.
+      payload['platform'] = Platform.isIOS ? 'ios' : 'android';
+      return 'FlareLane.syncDeviceDataCallback(${jsonEncode(payload)});';
+    } catch (e) {
+      debugPrint('[FlareLane] _webViewSyncPayload failed: $e');
+      return null;
+    }
+  }
+}
+
+// `window.FlareLaneBridge` mirrors the native Android JavascriptInterface
+// surface — the Web SDK detects it and forwards calls. We intentionally do
+// NOT install `window.webkit.messageHandlers.FlareLaneBridge` (the iOS hook).
+// The Web SDK calls both paths unconditionally; installing both would deliver
+// every action twice.
+//
+// `displayInApp` is intentionally omitted to match the native Android/iOS
+// SDK bridges: the Web SDK renders in-app messages inside the webview itself
+// using device data synced via `syncDeviceData`.
+const String _injectionScript = '''
+(function () {
+  if (window.__flareLaneBridgeInstalled) return;
+  window.__flareLaneBridgeInstalled = true;
+
+  function post(payload) {
+    try {
+      var ch = window.FlareLaneNativeBridge;
+      if (ch && typeof ch.postMessage === 'function') {
+        ch.postMessage(JSON.stringify(payload));
+      }
+    } catch (e) {}
+  }
+
+  window.FlareLaneBridge = {
+    syncDeviceData: function () { post({ method: 'syncDeviceData' }); },
+    setUserId: function (userId) { post({ method: 'setUserId', userId: userId }); },
+    setTags: function (jsonString) {
+      var tags = {}; try { tags = JSON.parse(jsonString); } catch (e) {}
+      post({ method: 'setTags', tags: tags });
+    },
+    trackEvent: function (type, jsonString) {
+      var data = null; if (jsonString) { try { data = JSON.parse(jsonString); } catch (e) {} }
+      post({ method: 'trackEvent', type: type, data: data });
+    },
+    setUserAttributes: function (jsonString) {
+      var attributes = {}; try { attributes = JSON.parse(jsonString); } catch (e) {}
+      post({ method: 'setUserAttributes', attributes: attributes });
+    }
+  };
+})();
+''';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -54,6 +54,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_inappwebview:
+    dependency: "direct dev"
+    description:
+      name: flutter_inappwebview
+      sha256: d198297060d116b94048301ee6749cd2e7d03c1f2689783f52d210a6b7aba350
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.8.0"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -71,26 +79,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -131,6 +139,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -180,18 +196,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.6"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -200,6 +216,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "15.0.0"
+  webview_flutter:
+    dependency: "direct dev"
+    description:
+      name: webview_flutter
+      sha256: a3da219916aba44947d3a5478b1927876a09781174b5a2b67fa5be0555154bf9
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.13.1"
+  webview_flutter_android:
+    dependency: transitive
+    description:
+      name: webview_flutter_android
+      sha256: ad5182eff9a550925330cb9f0cb038eddfdd5712aba8b77aa0f0400e50f6e688
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.12.0"
+  webview_flutter_platform_interface:
+    dependency: transitive
+    description:
+      name: webview_flutter_platform_interface
+      sha256: "1221c1b12f5278791042f2ec2841743784cf25c5a644e23d6680e5d718824f04"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.15.1"
+  webview_flutter_wkwebview:
+    dependency: transitive
+    description:
+      name: webview_flutter_wkwebview
+      sha256: e50cd97ad28e888f6a4f862a05eab917a635417f9b134df64c3abb78250c6446
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.25.0"
 sdks:
-  dart: ">=3.7.0-0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  dart: ">=3.9.0 <4.0.0"
+  flutter: ">=3.35.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flarelane_flutter
 description: FlareLane Flutter SDK
-version: 1.9.2
+version: 1.10.0
 homepage: https://flarelane.com
 
 environment:
@@ -15,6 +15,11 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^1.0.0
+  # Webview adapters under `lib/adapters/` import these packages. They're
+  # dev-only deps so consumers of this SDK don't pull them in — customers
+  # add only the library they actually use to their own app pubspec.
+  webview_flutter: ^4.7.0
+  flutter_inappwebview: ^5.8.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/test/adapters_flutter_inappwebview_test.dart
+++ b/test/adapters_flutter_inappwebview_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:flarelane_flutter/adapters/flutter_inappwebview.dart';
+
+/// Spec for the `flutter_inappwebview` adapter
+/// (`flarelane_flutter/adapters/flutter_inappwebview.dart`).
+///
+/// Pins the public shape and the user-script injection timing, since the
+/// timing (AT_DOCUMENT_START) is what lets the Web SDK detect
+/// `window.FlareLaneBridge` before its own scripts evaluate.
+void main() {
+  group('FlareLaneJavascriptInterface (flutter_inappwebview)', () {
+    test('BRIDGE_NAME matches the standard channel name', () {
+      expect(FlareLaneJavascriptInterface.BRIDGE_NAME,
+          equals('FlareLaneNativeBridge'));
+    });
+
+    test('initialUserScripts contains exactly one document-start script', () {
+      final scripts = FlareLaneJavascriptInterface.initialUserScripts;
+      expect(scripts, hasLength(1));
+      expect(scripts.first.injectionTime,
+          equals(UserScriptInjectionTime.AT_DOCUMENT_START));
+    });
+
+    test('initialUserScripts source installs the FlareLaneBridge shim and the flutter_inappwebview channel adapter', () {
+      final source = FlareLaneJavascriptInterface.initialUserScripts.first.source;
+      // bridge shim (from core javaScriptInjection)
+      expect(source, contains('window.FlareLaneBridge'));
+      // channel adapter for flutter_inappwebview's callHandler API
+      expect(source, contains('window.flutter_inappwebview.callHandler'));
+      expect(source, contains('FlareLaneNativeBridge'));
+    });
+
+    test('handlerCallback is a factory returning a function', () {
+      // Just confirm the factory exists — calling it requires an
+      // InAppWebViewController which can't be instantiated outside a real
+      // webview. Functional behavior is exercised by the bridge-core tests
+      // + the example app e2e flow.
+      expect(FlareLaneJavascriptInterface.handlerCallback, isA<Function>());
+    });
+  });
+}

--- a/test/adapters_webview_flutter_test.dart
+++ b/test/adapters_webview_flutter_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flarelane_flutter/adapters/webview_flutter.dart';
+
+/// Spec for the `webview_flutter` adapter
+/// (`flarelane_flutter/adapters/webview_flutter.dart`).
+///
+/// The adapter is a thin facade that delegates to the bridge core; tests
+/// here pin the public shape (constant name, factory signatures) so the
+/// surface stays stable. Functional behavior of `onMessageReceived` /
+/// `onPageStarted` is covered by the bridge-core tests + e2e example apps,
+/// since constructing a real `WebViewController` requires platform setup.
+void main() {
+  group('FlareLaneJavascriptInterface (webview_flutter)', () {
+    test('BRIDGE_NAME matches the standard channel name', () {
+      expect(FlareLaneJavascriptInterface.BRIDGE_NAME,
+          equals('FlareLaneNativeBridge'));
+    });
+
+    test('exposes the three documented members for slot wiring', () {
+      // Symbol-level presence check — the adapter class must keep these
+      // three members exactly to keep the README snippets compilable.
+      expect(FlareLaneJavascriptInterface.BRIDGE_NAME, isA<String>());
+      expect(FlareLaneJavascriptInterface.onMessageReceived, isA<Function>());
+      expect(FlareLaneJavascriptInterface.onPageStarted, isA<Function>());
+    });
+  });
+}

--- a/test/bridge_core_test.dart
+++ b/test/bridge_core_test.dart
@@ -56,6 +56,41 @@ void main() {
       expect(calls.where((c) => c.method == '_webViewSyncPayload'), hasLength(1));
     });
 
+    test(
+        'syncDeviceData still emits a callback with null identifiers when native returns all nulls',
+        () async {
+      // Native (iOS/Android) sends an all-null map when the SDK hasn't
+      // resolved identifiers yet (pre-init / pre-handshake). The Web SDK
+      // still expects a syncDeviceDataCallback invocation so it can react
+      // to "no identifiers yet" instead of waiting indefinitely.
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall call) async {
+        calls.add(call);
+        if (call.method == '_webViewSyncPayload') {
+          return <String, dynamic>{
+            'projectId': null,
+            'deviceId': null,
+            'userId': null,
+          };
+        }
+        return null;
+      });
+
+      final String? js =
+          await BridgeCore.handle(jsonEncode({'method': 'syncDeviceData'}));
+
+      expect(js, isNotNull);
+      final String jsonString = js!
+          .replaceFirst('FlareLane.syncDeviceDataCallback(', '')
+          .replaceFirst(RegExp(r'\);\s*$'), '');
+      final Map<String, dynamic> payload =
+          jsonDecode(jsonString) as Map<String, dynamic>;
+      expect(payload['projectId'], isNull);
+      expect(payload['deviceId'], isNull);
+      expect(payload['userId'], isNull);
+      expect(payload['platform'], anyOf(equals('ios'), equals('android')));
+    });
+
     test('setUserId forwards the userId to the native channel', () async {
       final String? js = await BridgeCore.handle(
         jsonEncode({'method': 'setUserId', 'userId': 'user-1'}),

--- a/test/bridge_core_test.dart
+++ b/test/bridge_core_test.dart
@@ -1,0 +1,151 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+// Internal — pinning the routing/injection contract that the adapters rely on.
+import 'package:flarelane_flutter/src/bridge_core.dart';
+
+/// Pins the JSON message routing + injection script shape that the adapters
+/// (`lib/adapters/webview_flutter.dart`, `lib/adapters/flutter_inappwebview.dart`)
+/// rely on. The Web SDK expects this exact contract.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const MethodChannel channel = MethodChannel('com.flarelane.flutter/methods');
+  final List<MethodCall> calls = <MethodCall>[];
+
+  setUp(() {
+    calls.clear();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (MethodCall call) async {
+      calls.add(call);
+      if (call.method == '_webViewSyncPayload') {
+        return <String, dynamic>{
+          'projectId': 'P',
+          'deviceId': 'D',
+          'userId': 'U',
+        };
+      }
+      return null;
+    });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  group('BridgeCore.handle', () {
+    test('syncDeviceData returns callback JS with the four canonical fields',
+        () async {
+      final String? js =
+          await BridgeCore.handle(jsonEncode({'method': 'syncDeviceData'}));
+
+      expect(js, isNotNull);
+      expect(js, startsWith('FlareLane.syncDeviceDataCallback('));
+      expect(js, endsWith(');'));
+
+      final String jsonString = js!
+          .replaceFirst('FlareLane.syncDeviceDataCallback(', '')
+          .replaceFirst(RegExp(r'\);\s*$'), '');
+      final Map<String, dynamic> payload = jsonDecode(jsonString) as Map<String, dynamic>;
+      expect(payload['projectId'], equals('P'));
+      expect(payload['deviceId'], equals('D'));
+      expect(payload['userId'], equals('U'));
+      expect(payload['platform'], anyOf(equals('ios'), equals('android')));
+      expect(calls.where((c) => c.method == '_webViewSyncPayload'), hasLength(1));
+    });
+
+    test('setUserId forwards the userId to the native channel', () async {
+      final String? js = await BridgeCore.handle(
+        jsonEncode({'method': 'setUserId', 'userId': 'user-1'}),
+      );
+
+      expect(js, isNull);
+      expect(calls.where((c) => c.method == 'setUserId'), hasLength(1));
+    });
+
+    test('setTags forwards the tags map to the native channel', () async {
+      await BridgeCore.handle(jsonEncode({
+        'method': 'setTags',
+        'tags': {'a': 'b'},
+      }));
+
+      expect(calls.where((c) => c.method == 'setTags'), hasLength(1));
+    });
+
+    test('trackEvent forwards type and optional data', () async {
+      await BridgeCore.handle(jsonEncode({
+        'method': 'trackEvent',
+        'type': 'purchase',
+        'data': {'sku': 'X'},
+      }));
+
+      expect(calls.where((c) => c.method == 'trackEvent'), hasLength(1));
+    });
+
+    test('setUserAttributes forwards attributes', () async {
+      await BridgeCore.handle(jsonEncode({
+        'method': 'setUserAttributes',
+        'attributes': {'name': 'Test'},
+      }));
+
+      expect(calls.where((c) => c.method == 'setUserAttributes'), hasLength(1));
+    });
+
+    test('unknown method is ignored (no native call, no throw)', () async {
+      final String? js =
+          await BridgeCore.handle(jsonEncode({'method': 'somethingNew'}));
+      expect(js, isNull);
+    });
+
+    test('malformed JSON does not throw', () async {
+      final String? js = await BridgeCore.handle('{not json');
+      expect(js, isNull);
+    });
+
+    test('missing method is ignored', () async {
+      final String? js = await BridgeCore.handle(jsonEncode({'foo': 'bar'}));
+      expect(js, isNull);
+      expect(calls, isEmpty);
+    });
+  });
+
+  group('BridgeCore.javaScriptInjection', () {
+    test('targets the standard FlareLaneNativeBridge channel', () {
+      expect(BridgeCore.javaScriptInjection,
+          contains('window.FlareLaneNativeBridge'));
+    });
+
+    test('exposes window.FlareLaneBridge with the five bridge methods', () {
+      const script = BridgeCore.javaScriptInjection;
+      expect(script, contains('window.FlareLaneBridge'));
+      for (final method in const [
+        'syncDeviceData',
+        'setUserId',
+        'setTags',
+        'trackEvent',
+        'setUserAttributes',
+      ]) {
+        expect(script, contains(method));
+      }
+    });
+
+    test('does not install displayInApp on the bridge', () {
+      // Matches the native Android/iOS bridge surface — the Web SDK handles
+      // in-app rendering inside the webview itself.
+      expect(BridgeCore.javaScriptInjection,
+          isNot(matches(RegExp(r'displayInApp\s*:'))));
+    });
+
+    test('does not install window.webkit.messageHandlers shim', () {
+      expect(BridgeCore.javaScriptInjection,
+          isNot(contains('window.webkit')));
+    });
+
+    test('is idempotent (guarded by __flareLaneBridgeInstalled)', () {
+      expect(BridgeCore.javaScriptInjection,
+          contains('__flareLaneBridgeInstalled'));
+    });
+  });
+}

--- a/test/notification_test.dart
+++ b/test/notification_test.dart
@@ -1,0 +1,138 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flarelane_flutter/notification.dart';
+
+/// Spec for [FlareLaneNotification.fromJson] parsing. The class is a thin read-only data
+/// holder; native (Android/iOS) computes derived fields (`clickedButton`, `clickedUrl`) and
+/// hands them over via the bridge — these tests pin the parsing contract so future bridge
+/// schema changes can't silently drop fields.
+void main() {
+  group('FlareLaneNotification', () {
+    test('parses a body click payload (no buttons)', () {
+      final notification = FlareLaneNotification({
+        'id': 'n1',
+        'body': 'hello',
+        'url': 'https://example.com/body',
+        'clickedButtonIndex': null,
+        'clickedButton': null,
+        'clickedUrl': 'https://example.com/body',
+      });
+
+      expect(notification.id, 'n1');
+      expect(notification.body, 'hello');
+      expect(notification.url, 'https://example.com/body');
+      expect(notification.buttons, isNull);
+      expect(notification.clickedButtonIndex, isNull);
+      expect(notification.clickedButton, isNull);
+      // Body click branch: clickedUrl = body url.
+      expect(notification.clickedUrl, 'https://example.com/body');
+    });
+
+    test('parses a button click payload (button has link)', () {
+      final notification = FlareLaneNotification({
+        'id': 'n2',
+        'body': 'hello',
+        'url': 'https://example.com/body',
+        'buttons': [
+          {'label': 'Open', 'link': 'https://example.com/a'},
+          {'label': 'Share'},
+        ],
+        'clickedButtonIndex': 0,
+        'clickedButton': {'label': 'Open', 'link': 'https://example.com/a'},
+        'clickedUrl': 'https://example.com/a',
+      });
+
+      expect(notification.buttons?.length, 2);
+      expect(notification.buttons?[0].label, 'Open');
+      expect(notification.buttons?[0].link, 'https://example.com/a');
+      expect(notification.buttons?[1].label, 'Share');
+      expect(notification.buttons?[1].link, isNull);
+      expect(notification.clickedButtonIndex, 0);
+      expect(notification.clickedButton?.label, 'Open');
+      expect(notification.clickedButton?.link, 'https://example.com/a');
+      expect(notification.clickedUrl, 'https://example.com/a');
+    });
+
+    test(
+      'parses a button click without link — clickedUrl is null, NOT the body url',
+      () {
+        // This is the critical "no cross-fallback" guard: when the user taps a button that
+        // has no link, the bridge sends clickedUrl=null. The data class must surface that
+        // null and not silently substitute the body's url, which would be a different
+        // destination than what the click carried.
+        final notification = FlareLaneNotification({
+          'id': 'n3',
+          'body': 'hello',
+          'url': 'https://example.com/body',
+          'buttons': [
+            {'label': 'NoLink'},
+          ],
+          'clickedButtonIndex': 0,
+          'clickedButton': {'label': 'NoLink'},
+          'clickedUrl': null,
+        });
+
+        expect(notification.clickedButtonIndex, 0);
+        expect(notification.clickedButton?.label, 'NoLink');
+        expect(notification.clickedButton?.link, isNull);
+        expect(notification.clickedUrl, isNull);
+        expect(notification.url, 'https://example.com/body');
+      },
+    );
+
+    test('parses out-of-range button click (clickedButton=null, clickedUrl=null)', () {
+      final notification = FlareLaneNotification({
+        'id': 'n4',
+        'body': 'hello',
+        'url': 'https://example.com/body',
+        'buttons': [
+          {'label': 'Only', 'link': 'https://example.com/only'},
+        ],
+        // OS reported a button slot tap but native couldn't resolve the button (stale
+        // category cache, etc.). Index stays set so callers can still tell "it was a
+        // button click", but the button object and clickedUrl are null.
+        'clickedButtonIndex': 5,
+        'clickedButton': null,
+        'clickedUrl': null,
+      });
+
+      expect(notification.clickedButtonIndex, 5);
+      expect(notification.clickedButton, isNull);
+      expect(notification.clickedUrl, isNull);
+    });
+
+    test('parses data as Map (both iOS and Android bridges send Map now)', () {
+      final notification = FlareLaneNotification({
+        'id': 'n5',
+        'body': 'hello',
+        'data': {'key': 'value'},
+      });
+      expect(notification.data, {'key': 'value'});
+    });
+
+    test('skips malformed button entries instead of throwing', () {
+      final notification = FlareLaneNotification({
+        'id': 'n7',
+        'body': 'hello',
+        // Mixed list — native should only forward Map-shaped entries with valid labels,
+        // but guard anyway so a wire-format hiccup can't crash the callback. Any of:
+        //   - non-Map (string/int) entries
+        //   - Map entries with missing / non-string / empty `label`
+        // are dropped silently.
+        'buttons': [
+          {'label': 'Good', 'link': 'https://example.com/a'},
+          'not-a-map',
+          42,
+          {'link': 'https://example.com/no-label'}, // missing label
+          {'label': null, 'link': 'https://example.com/null-label'}, // null label
+          {'label': '', 'link': 'https://example.com/empty-label'}, // empty label
+          {'label': 99, 'link': 'https://example.com/int-label'}, // wrong-type label
+          {'label': 'AlsoGood'},
+        ],
+      });
+
+      expect(notification.buttons?.length, 2);
+      expect(notification.buttons?[0].label, 'Good');
+      expect(notification.buttons?[1].label, 'AlsoGood');
+    });
+  });
+}


### PR DESCRIPTION
- Add `setUserAttributes` public method.
- Add notification action button surface: `buttons`, `clickedButtonIndex`, `clickedButton`, `clickedUrl`.
- Add `FlareLaneJavascriptInterface` adapter for `webview_flutter` and `flutter_inappwebview` hybrid apps (see README).
- Bump native dependencies to FlareLane Android/iOS SDK 1.10.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 하이브리드 앱을 위한 WebView 브리지 연결이 추가되어 네이티브-웹 간 identity 및 SDK 호출 동기화가 가능해졌습니다.
  * 사용자 속성(`setUserAttributes`) 설정 기능을 추가했습니다.
  * 알림에 버튼/클릭된 버튼 정보 및 클릭 URL을 포함하도록 확장했습니다.
* **Bug Fixes**
  * WebView 주입·메시지 처리 안정성과 알림 데이터 파싱이 더 견고해졌습니다.
* **Documentation**
  * “WebView Bridge (hybrid apps)” 안내 문서를 추가했습니다.
* **Tests**
  * 브리지/어댑터/알림 관련 테스트를 추가했습니다.
* **Chores**
  * SDK 및 예제 프로젝트 설정을 최신 버전에 맞게 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->